### PR TITLE
fix: reorder promise chain to handle failures

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -169,7 +169,7 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
               // Spoof error code 400 to avoid retrying the request
               return callback({ error: res.statusMessage, code: 400 })
             }
-            return callback(null, resBodyJSON, body.registration_ids || [body.to])
+            callback(null, resBodyJSON, body.registration_ids || [body.to])
           })
           .catch((err) => {
             debug(`GCM service failed: ${err.response?.status}`)

--- a/lib/sender.js
+++ b/lib/sender.js
@@ -163,17 +163,17 @@ Sender.prototype.sendNoRetry = function(message, recipient, callback) {
         }
 
         axios(axios_options)
-          .catch((err) => {
-            debug(`GCM service failed: ${err.response?.status}`)
-            return callback(err.response?.status ?? 400)
-          })
           .then(({ data: resBodyJSON }) => {
             if (!resBodyJSON) {
               debug('Empty response received (' + res.statusCode + ' ' + res.statusMessage + ')')
               // Spoof error code 400 to avoid retrying the request
               return callback({ error: res.statusMessage, code: 400 })
             }
-            callback(null, resBodyJSON, body.registration_ids || [body.to])
+            return callback(null, resBodyJSON, body.registration_ids || [body.to])
+          })
+          .catch((err) => {
+            debug(`GCM service failed: ${err.response?.status}`)
+            return callback(err.response?.status ?? 400)
           })
     }.bind(this));
 };


### PR DESCRIPTION
```
uncaughtException
TypeError: Cannot destructure property 'data' of 'undefined' as it is undefined.
    at /app/node_modules/node-gcm/lib/sender.js:170:26
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

<img width="820" alt="image" src="https://user-images.githubusercontent.com/29136191/222798642-f5783ed7-bc14-4e64-b46e-877d044cca21.png">
